### PR TITLE
Ensure we parse RDL without prefixing 0

### DIFF
--- a/src/components/notamUtils.ts
+++ b/src/components/notamUtils.ts
@@ -593,7 +593,7 @@ export class NOTAM {
     // Look for relative locations, only if no other location has been found
     if (layers.length == 0) {
       const relativePlacePattern =
-        /RDL\s*(?<azimuth>\d{3})\s*\/\s*(?<distance>\d+([.,]\d+))\s*(?<unit>\w+)/gm
+        /RDL\s*(?<azimuth>\d{2,3})\s*\/\s*(?<distance>\d+([.,]\d+))\s*(?<unit>\w+)/gm
 
       while ((match = relativePlacePattern.exec(text)) != null) {
         if (match.groups === undefined) {


### PR DESCRIPTION
Found a NOTAM with RDL28 instead of RDL028